### PR TITLE
Monitoring extension

### DIFF
--- a/DEV.org
+++ b/DEV.org
@@ -3,6 +3,10 @@
 #+SEQ_TODO: TODO(t) STARTED(s) WAITING(w@) | DONE(d) CANCELLED(c@)
 
 * Next release (1.0)
+** TODO add help() to ubx_launch
+** TODO proper tostring meta method for ubx_types
+** TODO add possibility to identify trigger blocks
+   - useful for shutting down
 ** TODO remove port state (?)
    - this is not used, and its also questionable who should control
      this. At least remove it from the ubx_port_add function, because

--- a/DEV.org
+++ b/DEV.org
@@ -3,6 +3,12 @@
 #+SEQ_TODO: TODO(t) STARTED(s) WAITING(w@) | DONE(d) CANCELLED(c@)
 
 * Next release (1.0)
+** TODO remove port state (?)
+   - this is not used, and its also questionable who should control
+     this. At least remove it from the ubx_port_add function, because
+     for sure the block (who uses this function) should NOT be doing
+     it.
+
 ** TODO non recursive make
 ** DONE luajit-2.1.0-beta3 crashes with reflect
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([libubx_if_age], [4])      dnl inc if API changes are backwards compat
 
 AC_INIT([microblx], [package_version_major.package_version_minor.package_version_micro])
 #AC_CONFIG_SRCDIR([libubx/ubx.c])
-AM_INIT_AUTOMAKE([foreign -Wall -Wextra])
+AM_INIT_AUTOMAKE([foreign -Wall])
 
 AC_SUBST([AM_CFLAGS], [-Wall -Wextra -Werror])
 
@@ -84,6 +84,7 @@ std_blocks/mqueue/Makefile
 std_blocks/ptrig/Makefile
 std_blocks/trig/Makefile
 std_blocks/random/Makefile
+std_blocks/const/Makefile
 std_blocks/ramp/Makefile
 std_blocks/simple_fifo/Makefile
 std_blocks/webif/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,9 @@ m4_define([libubx_if_age], [4])      dnl inc if API changes are backwards compat
 
 AC_INIT([microblx], [package_version_major.package_version_minor.package_version_micro])
 #AC_CONFIG_SRCDIR([libubx/ubx.c])
-AM_INIT_AUTOMAKE([foreign -Wall])
+AM_INIT_AUTOMAKE([foreign -Wall -Wextra])
+
+AC_SUBST([AM_CFLAGS], [-Wall -Wextra -Werror])
 
 # compilers
 AC_PROG_CC

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -1,6 +1,14 @@
 Frequently asked questions
 ==========================
 
+# fix "error object is not a string"
+
+This is most of the time happens when the `strict` module being loaded
+(also indirectly, e.g. via ubx.lua) in a luablock. It is caused by the
+C code looking up a non-existing global hook function. Solution:
+either define all hooks or disable the strict module for the luablock.
+
+
 # `blockXY`.so or `liblfds611.so.0`: cannot open shared object file: No such file or directory
 
 Often this means that the location of the shared object file is not in

--- a/examples/systemmodels/minimal.usc
+++ b/examples/systemmodels/minimal.usc
@@ -1,4 +1,5 @@
 -- -*- mode: lua; -*-
+local bd = require("blockdiagram")
 
 return bd.system {
    imports={

--- a/libubx/ubx.c
+++ b/libubx/ubx.c
@@ -2112,6 +2112,11 @@ int ubx_clock_mono_nanosleep(struct ubx_timespec* uts)
 	ts.tv_sec += uts->sec;
 	ts.tv_nsec += uts->nsec;
 
+	if(ts.tv_nsec >= NSEC_PER_SEC) {
+		ts.tv_sec+=ts.tv_nsec / NSEC_PER_SEC;
+		ts.tv_nsec=ts.tv_nsec % NSEC_PER_SEC;
+	}
+
 	for (;;) {
 		ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, NULL);
 		if (ret != EINTR) {

--- a/libubx/ubx.c
+++ b/libubx/ubx.c
@@ -682,7 +682,7 @@ int ubx_data_assign(ubx_data_t *tgt, ubx_data_t *src)
 		goto out;
 	}
 
-	if(tgt->len != tgt->len) {
+	if(src->len != tgt->len) {
 		ERR("length mismatch: %lu <-> %lu", tgt->len, src->len);
 		goto out;
 	}

--- a/libubx/ubx.c
+++ b/libubx/ubx.c
@@ -1648,6 +1648,36 @@ int ubx_port_add(ubx_block_t* b, const char* name, const char* doc,
 }
 
 /**
+ * ubx_outport_add - add an output port
+ *
+ * @param b
+ * @param name
+ * @param out_type_name
+ * @param out_data_len
+ * @return < 0 in case of error, 0 otherwise
+ */
+int ubx_outport_add(ubx_block_t* b, const char* name, const char* doc,
+		    const char* out_type_name, unsigned long out_data_len)
+{
+	return ubx_port_add(b, name, doc, NULL, 0, out_type_name, out_data_len, 1);
+}
+
+/**
+ * ubx_inport_add - add an input-port
+ *
+ * @param b
+ * @param name
+ * @param in_type_name
+ * @param in_data_len
+ * @return < 0 in case of error, 0 otherwise
+ */
+int ubx_inport_add(ubx_block_t* b, const char* name, const char* doc,
+		   const char* in_type_name, unsigned long in_data_len)
+{
+	return ubx_port_add(b, name, doc, in_type_name, in_data_len, NULL, 0, 1);
+}
+
+/**
  * ubx_port_rm - remove a port from a block.
  *
  * @param b

--- a/libubx/ubx_proto.h
+++ b/libubx/ubx_proto.h
@@ -44,6 +44,8 @@ int ubx_config_add(ubx_block_t *b, const char *name, const char *meta, const cha
 int ubx_config_rm(ubx_block_t *b, const char *name);
 unsigned int get_num_ports(ubx_block_t *b);
 int ubx_port_add(ubx_block_t *b, const char *name, const char *doc, const char *in_type_name, unsigned long in_data_len, const char *out_type_name, unsigned long out_data_len, uint32_t state);
+int ubx_outport_add(ubx_block_t *b, const char *name, const char *doc, const char *out_type_name, unsigned long out_data_len);
+int ubx_inport_add(ubx_block_t *b, const char *name, const char *doc, const char *in_type_name, unsigned long in_data_len);
 int ubx_port_rm(ubx_block_t *b, const char *name);
 ubx_port_t *ubx_port_get(ubx_block_t *b, const char *name);
 int ubx_block_init(ubx_block_t *b);

--- a/libubx/ubx_types.h
+++ b/libubx/ubx_types.h
@@ -37,7 +37,7 @@
 
 /* constants */
 enum {
-	BLOCK_NAME_MAXLEN	= 100,
+	BLOCK_NAME_MAXLEN	= 30,
 	TYPE_HASH_LEN		= 16,   /* md5 */
 	TYPE_HASH_LEN_UNIQUE	= 8	/* Number of characters of the
 					   type checksum to compare */

--- a/lua/blockdiagram.lua
+++ b/lua/blockdiagram.lua
@@ -416,6 +416,8 @@ function system.launch(self, t)
    end
 
    -- fire it up
+   t = t or {}
+   t.nodename = t.nodename or "node-"..os.date("%Y%m%d_%H%M%S")
    local ni = ubx.node_create(t.nodename)
 
    -- import modules

--- a/lua/blockdiagram.lua
+++ b/lua/blockdiagram.lua
@@ -14,6 +14,18 @@ local green=ubx.green
 local yellow=ubx.yellow
 local magenta=ubx.magenta
 
+
+local ind_log = -1
+local ind_mul = 4
+local verbose = true
+
+local function log(first, ...)
+   if verbose then
+      print(string.rep(' ', ind_log*ind_mul)..tostring(first), ...)
+   end
+end
+
+
 local AnySpec=umf.AnySpec
 local NumberSpec=umf.NumberSpec
 local StringSpec=umf.StringSpec
@@ -199,15 +211,6 @@ function system.launch(self, t)
       self:validate(true)
       os.exit(1)
    end
-
-   local log
-   local ind_log = -1
-   local ind_mul = 4
-   if t.verbose then
-      log=function(first, ...)
-	 print(string.rep(' ', ind_log*ind_mul)..tostring(first), ...)
-      end
-   else log=function() end end
 
    --- Generate a list of all blockdiagram.blocks to be created
    -- @param blockdiagram.system

--- a/lua/blockdiagram.lua
+++ b/lua/blockdiagram.lua
@@ -418,6 +418,8 @@ function system.launch(self, t)
    -- fire it up
    t = t or {}
    t.nodename = t.nodename or "node-"..os.date("%Y%m%d_%H%M%S")
+   verbose = t.verbose
+
    local ni = ubx.node_create(t.nodename)
 
    -- import modules

--- a/lua/ubx.lua
+++ b/lua/ubx.lua
@@ -1230,7 +1230,7 @@ end
 function M.node_todot(ni)
 
    --- Generate a list of block nodes in graphviz dot syntax
-   function gen_dot_nodes(blocks)
+   local function gen_dot_nodes(blocks)
       local function block2color(b)
 	 if b.state == 'preinit' then return "blue"
 	 elseif b.state == 'inactive' then return "red"
@@ -1249,7 +1249,7 @@ function M.node_todot(ni)
    end
 
    --- Add trigger edges
-   function gen_dot_trigger_edges(b, res)
+   local function gen_dot_trigger_edges(b, res)
 
       if not (b.prototype=="std_triggers/ptrig" or
 	      b.prototype=="std_triggers/trig") then return end
@@ -1267,7 +1267,7 @@ function M.node_todot(ni)
    end
 
    --- Generate edges
-   function gen_dot_edges(blocks)
+   local function gen_dot_edges(blocks)
       local res = {}
       for _,b in ipairs(blocks) do
 	 for _,p in ipairs(b.ports) do

--- a/lua/ubx.lua
+++ b/lua/ubx.lua
@@ -439,6 +439,8 @@ local ubx_block_mt = {
       p = M.block_port_get,
       port_get = M.block_port_get,
       port_add = ubx.ubx_port_add,
+      inport_add = ubx.ubx_inport_add,
+      outport_add = ubx.ubx_outport_add,
       port_rm = ubx.ubx_port_rm,
 
       c = M.block_config_get,

--- a/lua/ubx.lua
+++ b/lua/ubx.lua
@@ -38,7 +38,7 @@ local utils= require "utils"
 local ts=tostring
 local ac=require "ansicolors"
 local time=require"time"
-require "strict"
+-- require "strict"
 
 local M={}
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,4 +3,5 @@
 for t in tests/test_*.lua; do
     echo "running $t"
     luajit $t
+    echo "----------------------------------------------------------------"
 done

--- a/std_blocks/Makefile.am
+++ b/std_blocks/Makefile.am
@@ -7,6 +7,7 @@ SUBDIRS = cppdemo \
           ptrig \
           trig \
           random \
+          const \
           ramp \
           simple_fifo \
           webif

--- a/std_blocks/const/Makefile.am
+++ b/std_blocks/const/Makefile.am
@@ -1,0 +1,11 @@
+# const_int block
+
+ubxmoddir = $(ubx_moddir)
+ubxmod_LTLIBRARIES = const_int.la
+
+const_int_la_includes = $(top_srcdir)/libubx/ubx.h
+const_int_la_SOURCES = $(const_int_la_includes) \
+                     const_int.c
+const_int_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+const_int_la_LIBADD = $(top_builddir)/libubx/libubx.la
+const_int_la_CPPFLAGS = -I$(top_srcdir)/libubx

--- a/std_blocks/const/const-test.usc
+++ b/std_blocks/const/const-test.usc
@@ -1,0 +1,45 @@
+-- -*- mode: lua; -*-
+
+local bd = require("blockdiagram")
+
+local logger_block = [[
+local ubx=require "ubx"
+
+local p_in
+
+function init(b)
+   ubx.inport_add(b, "in", "int port that will be logged", "int", 1)
+   p_in = ubx.port_get(b, "in")
+   return true
+end
+
+function start(b)
+   return true
+end
+
+function step(b)
+   local n, res = p_in:read()
+   print(n, res:tolua())
+end
+]]
+
+return bd.system
+{
+   imports = { "stdtypes", "const_int", "logger", "luablock" },
+
+   blocks = {
+      { name="const1", type="consts/const_int" },
+      { name="logger1", type="lua/luablock" },
+   },
+
+   connections = {
+      { src="const1", tgt="logger1.in"}
+   },
+
+   configurations = {
+      { name="const1", config = {value=47} },
+      { name="logger1", config = { lua_str=logger_block } },
+   },
+
+   start = { "const1", "logger1" }
+}

--- a/std_blocks/const/const_int.c
+++ b/std_blocks/const/const_int.c
@@ -1,0 +1,122 @@
+/*
+ * An constant value interaction.
+ */
+
+/* #define DEBUG 1 */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* #define DEBUG 1 */
+#include "ubx.h"
+
+UBX_MODULE_LICENSE_SPDX(BSD-3-Clause)
+
+char const_int_meta[] =
+	"{ doc='const int interaction',"
+	"  license='MIT',"
+	"  real-time=false,"
+	"}";
+
+ubx_config_t const_int_config[] = {
+	{ .name="value", .type_name = "int" },
+	{ NULL },
+};
+
+struct blk_inf {
+	ubx_type_t *type;
+	int* value;
+};
+
+
+static int const_int_init(ubx_block_t *i)
+{
+	DBG("");
+	int ret = -1;
+	struct blk_inf *inf;
+
+	if((i->private_data = calloc(1, sizeof(struct blk_inf)))==NULL) {
+		ERR("failed to alloc blk_info");
+		ret = EOUTOFMEM;
+		goto out;
+	}
+
+
+	inf = (struct blk_inf*) i->private_data;
+
+	inf->type = ubx_type_get(i->ni, "int");
+
+	if(inf->type == NULL) {
+		ERR("%s: failed to lookup type int");
+		ret = EINVALID_CONFIG;
+		goto out;
+	}
+	ret = 0;
+out:
+	return ret;
+}
+
+static int const_int_start(ubx_block_t *i)
+{
+	DBG("");
+	int len;
+	struct blk_inf *inf;
+	inf = (struct blk_inf*) i->private_data;
+	inf->value = (int*) ubx_config_get_data_ptr(i, "value", &len);
+	return 0;
+}
+
+static void const_int_cleanup(ubx_block_t *i)
+{
+	free(i->private_data);
+}
+
+static int const_int_read(ubx_block_t *i, ubx_data_t* data)
+{
+	DBG("");
+	int ret = 0;
+	struct blk_inf *inf;
+	inf = (struct blk_inf*) i->private_data;
+
+	if(inf->type != data->type) {
+		ERR("%s: invalid read target type %s (should be int)",
+		    i->name, data->type->name);
+		goto out;
+	}
+
+	assert(sizeof(int) == data_size(data));
+	memcpy(data->data, inf->value, sizeof(int));
+	ret = 1;
+out:
+	return ret;
+}
+
+
+/* put everything together */
+ubx_block_t const_int_comp = {
+	.name = "consts/const_int",
+	.type = BLOCK_TYPE_INTERACTION,
+	.meta_data = const_int_meta,
+	.configs = const_int_config,
+
+	/* ops */
+	.init = const_int_init,
+	.start = const_int_start,
+	.cleanup = const_int_cleanup,
+	.read = const_int_read,
+};
+
+static int const_int_mod_init(ubx_node_info_t* ni)
+{
+	DBG(" ");
+	return ubx_block_register(ni, &const_int_comp);
+}
+
+static void const_int_mod_cleanup(ubx_node_info_t *ni)
+{
+	DBG(" ");
+	ubx_block_unregister(ni, "const_int/const_int");
+}
+
+UBX_MODULE_INIT(const_int_mod_init)
+UBX_MODULE_CLEANUP(const_int_mod_cleanup)

--- a/std_blocks/lfds_buffers/lfds_cyclic.c
+++ b/std_blocks/lfds_buffers/lfds_cyclic.c
@@ -122,7 +122,7 @@ static int cyclic_init(ubx_block_t *i)
 	}
 
 	/* cache port ptrs */
-	assert(bbi->p_overruns = ubx_port_get(i, "overruns"));
+	bbi->p_overruns = ubx_port_get(i, "overruns");
 
 	ret=0;
 	goto out;

--- a/std_blocks/lfds_buffers/lfds_cyclic.c
+++ b/std_blocks/lfds_buffers/lfds_cyclic.c
@@ -112,7 +112,7 @@ static int cyclic_init(ubx_block_t *i)
 	}
 
 	DBG("%s: allocating ringbuffer with %lu elements of type %s [%lu] bytes.",
-	    i->name, bbi->buffer_len, type_name, ,bbi->data_len);
+	    i->name, bbi->buffer_len, type_name, bbi->data_len);
 
 	if(lfds611_ringbuffer_new(&bbi->rbs, bbi->buffer_len, cyclic_data_elem_init, bbi)==0) {
 		ERR("%s: allocating ringbuffer with %lu elements of type %s [%lu] bytes failed.",

--- a/std_blocks/ptrig/ptrig.c
+++ b/std_blocks/ptrig/ptrig.c
@@ -183,7 +183,8 @@ static int trigger_steps(struct ptrig_inf *inf)
 
 	/* output stats - TODO throttling */
 	for(i=0; i<inf->trig_list_len; i++) {
-		write_tstat(inf->p_tstats, &inf->blk_tstats[i]);
+		if(inf->trig_list[i].measure)
+			write_tstat(inf->p_tstats, &inf->blk_tstats[i]);
 	}
 
 	ret=0;
@@ -382,7 +383,7 @@ static int ptrig_start(ubx_block_t *b)
 	inf->trig_list_len = trig_list_data->len;
 
 	/* preparing timing statistics */
-	tstat_init(&inf->global_tstats, "__global__");
+	tstat_init(&inf->global_tstats, "##global##");
 
 	inf->blk_tstats = calloc(inf->trig_list_len, sizeof(struct ptrig_tstat));
 

--- a/std_blocks/ptrig/ptrig.c
+++ b/std_blocks/ptrig/ptrig.c
@@ -41,6 +41,10 @@ ubx_port_t ptrig_ports[] = {
 	  .out_type_name="struct ptrig_tstat",
 	  .doc="out port for totals and per block timing statistics"
 	},
+	{ .name="shutdown",
+	  .in_type_name="int",
+	  .doc="in port for stopping ptrig"
+	},
 	{ NULL },
 };
 
@@ -325,7 +329,6 @@ static int ptrig_init(ubx_block_t *b)
 	int ret = EOUTOFMEM;
 	const char* threadname;
 	struct ptrig_inf* inf;
-	int i;
 
 	if((b->private_data=calloc(1, sizeof(struct ptrig_inf)))==NULL) {
 		ERR("failed to alloc");
@@ -408,7 +411,7 @@ static int ptrig_start(ubx_block_t *b)
 	pthread_cond_signal(&inf->active_cond);
 	pthread_mutex_unlock(&inf->mutex);
 
-	assert(inf->p_tstats = ubx_port_get(b, "tstats"));
+	inf->p_tstats = ubx_port_get(b, "tstats");
 	ret = 0;
 
 out:

--- a/std_blocks/ptrig/ptrig.c
+++ b/std_blocks/ptrig/ptrig.c
@@ -75,8 +75,7 @@ ubx_config_t ptrig_config[] = {
 	},
 	{ .name="tstats_output_rate",
 	  .type_name = "unsigned int",
-	  .doc="output tstatso only on every \
-		tstats_output_rate'th trigger (0 to disable)"
+	  .doc="output tstats only on every tstats_output_rate'th trigger (0 to disable)"
 	},
 	{ NULL },
 };

--- a/std_blocks/ptrig/ptrig.c
+++ b/std_blocks/ptrig/ptrig.c
@@ -39,7 +39,7 @@ char ptrig_meta[] =
 ubx_port_t ptrig_ports[] = {
 	{ .name="tstats",
 	  .out_type_name="struct ptrig_tstat",
-	  .doc="out port for global and per block timing statistics"
+	  .doc="out port for totals and per block timing statistics"
 	},
 	{ NULL },
 };
@@ -67,7 +67,7 @@ ubx_config_t ptrig_config[] = {
 	  .doc="trigger conf: which block and how to trigger"
 	},
 	{ .name="tstats_enabled", .type_name = "int",
-	  .doc="enable global timing statistics over all blocks",
+	  .doc="enable timing statistics over all blocks",
 	},
 	{ .name="tstats_output_rate",
 	  .type_name = "unsigned int",
@@ -383,7 +383,7 @@ static int ptrig_start(ubx_block_t *b)
 	inf->trig_list_len = trig_list_data->len;
 
 	/* preparing timing statistics */
-	tstat_init(&inf->global_tstats, "##global##");
+	tstat_init(&inf->global_tstats, "##total##");
 
 	inf->blk_tstats = calloc(inf->trig_list_len, sizeof(struct ptrig_tstat));
 

--- a/std_blocks/ptrig/ptrig.c
+++ b/std_blocks/ptrig/ptrig.c
@@ -370,7 +370,7 @@ static int ptrig_init(ubx_block_t *b)
 static int ptrig_start(ubx_block_t *b)
 {
 	DBG(" ");
-
+	int ret = -1;
 	struct ptrig_inf *inf;
 	ubx_data_t* trig_list_data;
 
@@ -386,6 +386,11 @@ static int ptrig_start(ubx_block_t *b)
 	tstat_init(&inf->global_tstats, "##global##");
 
 	inf->blk_tstats = calloc(inf->trig_list_len, sizeof(struct ptrig_tstat));
+
+	if(!inf->blk_tstats) {
+		ERR("failed to alloc blk_stats");
+		goto out;
+	}
 
 	for(int i=0; i<inf->trig_list_len; i++) {
 		tstat_init(&inf->blk_tstats[i],
@@ -404,8 +409,10 @@ static int ptrig_start(ubx_block_t *b)
 	pthread_mutex_unlock(&inf->mutex);
 
 	assert(inf->p_tstats = ubx_port_get(b, "tstats"));
+	ret = 0;
 
-	return 0;
+out:
+	return ret;
 }
 
 static void ptrig_stop(ubx_block_t *b)

--- a/std_blocks/ptrig/types/ptrig_tstat.h
+++ b/std_blocks/ptrig/types/ptrig_tstat.h
@@ -1,7 +1,6 @@
 struct ptrig_tstat
 {
 	char block_name[BLOCK_NAME_MAXLEN];
-	struct ubx_timespec dur;
 	struct ubx_timespec min;
 	struct ubx_timespec max;
 	struct ubx_timespec total;

--- a/std_blocks/ptrig/types/ptrig_tstat.h
+++ b/std_blocks/ptrig/types/ptrig_tstat.h
@@ -1,7 +1,6 @@
-
 struct ptrig_tstat
 {
-	int block;
+	char block_name[BLOCK_NAME_MAXLEN];
 	struct ubx_timespec dur;
 	struct ubx_timespec min;
 	struct ubx_timespec max;

--- a/std_blocks/ramp/ramp.c
+++ b/std_blocks/ramp/ramp.c
@@ -44,11 +44,8 @@ out:
 /* start */
 int ramp_start(ubx_block_t *b)
 {
-	struct ramp_info *inf = (struct ramp_info*) b->private_data;
 	DBG("%s: start=%g, slope=%g",
-	    b->name,
-	    (double) inf->cur,
-	    (double) inf->slope);
+	    b->name, (double) inf->cur, (double) inf->slope);
 	return 0;
 }
 

--- a/std_blocks/random/random.c
+++ b/std_blocks/random/random.c
@@ -169,16 +169,17 @@ static void rnd_step(ubx_block_t *b) {
  */
 ubx_block_t random_comp = {
 	.name = "random/random",
-	.type = BLOCK_TYPE_COMPUTATION,
 	.meta_data = rnd_meta,
-	.configs = rnd_config,
+	.type = BLOCK_TYPE_COMPUTATION,
+
 	.ports = rnd_ports,
+	.configs = rnd_config,
 
 	/* ops */
 	.init = rnd_init,
 	.start = rnd_start,
-	.step = rnd_step,
 	.cleanup = rnd_cleanup,
+	.step = rnd_step,
 };
 
 /**

--- a/std_blocks/trig/trig.c
+++ b/std_blocks/trig/trig.c
@@ -157,7 +157,7 @@ int trig_start(ubx_block_t *b)
 	inf->trig_list = trig_list_data->data;
 	inf->trig_list_len = trig_list_data->len;
 
-	assert(inf->p_tstats = ubx_port_get(b, "tstats"));
+	inf->p_tstats = ubx_port_get(b, "tstats");
 
 	return 0;
 }

--- a/tests/test_ptrig.lua
+++ b/tests/test_ptrig.lua
@@ -1,5 +1,4 @@
 local luaunit=require("luaunit")
-local ffi=require("ffi")
 local ubx=require("ubx")
 local utils=require("utils")
 local bd = require("blockdiagram")
@@ -35,7 +34,7 @@ end
 
 function cleanup(block)
    ubx.port_rm(block, "ramp_cnt")
-   ubx.port_rm(block, "tstats")
+   ubx.port_rm(block, "test_result")
 end
 ]]
 
@@ -60,7 +59,7 @@ local sys1 = bd.system {
    },
 }
 
-function test_launch()
+function test_count_num_trigs()
    local ni = sys1:launch{ nostart=true, verbose=false }
    local p_result = ubx.port_clone_conn(ni:b("tester"), "test_result")
    sys1:startup(ni)
@@ -68,6 +67,63 @@ function test_launch()
    ni:b("trig"):stop()
    local _, res = p_result:read()
    assert_equals(res:tolua(), 999)
+   sys1:pulldown(ni)
 end
+
+
+---
+--- timing statistics test
+---
+
+local dur_test_block_tmpl = [[
+local ubx=require "ubx"
+
+function step(block)
+   ubx.clock_mono_sleep($SEC, $NSEC)
+end
+]]
+
+local function gen_dur_test_block(sec, nsec)
+   return utils.expand(dur_test_block_tmpl, { SEC=sec, NSEC=nsec})
+end
+
+
+local sys2 = bd.system {
+   imports = { "stdtypes", "ptrig", "lfds_cyclic", "luablock" },
+   blocks = {
+      { name="tb1", type="lua/luablock" },
+      { name="tb2", type="lua/luablock" },
+      { name="tb3", type="lua/luablock" },
+      { name="trig", type="std_triggers/ptrig" },
+   },
+   configurations = {
+      { name="tb1", config = { lua_str=gen_dur_test_block(0, 10*1000*1000) } },
+      { name="tb2", config = { lua_str=gen_dur_test_block(0, 50*1000*1000) } },
+      { name="tb3", config = { lua_str=gen_dur_test_block(0, 100*1000*1000) } },
+      { name="trig", config = { period = {sec=0, usec=100000 },
+				trig_blocks={
+				   { b="#tb1", num_steps=1, measure=1 },
+				   { b="#tb2", num_steps=1, measure=1 },
+				   { b="#tb3", num_steps=1, measure=1 } } } },
+   },
+}
+
+function test_tstats()
+   local ni = sys2:launch{ nostart=true, verbose=false }
+   local p_tstats = ubx.port_clone_conn(ni:b("trig"), "tstats", 10)
+
+   sys2:startup(ni)
+   ubx.clock_mono_sleep(3)
+   ni:b("trig"):stop()
+   while true do
+      local cnt, res = p_tstats:read()
+      if cnt <= 0 then break end
+      print(res)
+   end
+   -- give ptrig some time to shutdown cleanly
+   ubx.clock_mono_sleep(1)
+   sys2:pulldown(ni)
+end
+
 
 os.exit( luaunit.LuaUnit.run() )

--- a/tests/test_ptrig.lua
+++ b/tests/test_ptrig.lua
@@ -1,0 +1,73 @@
+local luaunit=require("luaunit")
+local ffi=require("ffi")
+local ubx=require("ubx")
+local utils=require("utils")
+local bd = require("blockdiagram")
+
+local assert_equals = luaunit.assert_equals
+
+local count_num_trigs = [[
+local ubx=require "ubx"
+
+local ramp_cnt, test_result
+
+function init(b)
+   ubx.inport_add(b, "ramp_cnt", "ramp counter in", "uint64_t", 1)
+   ubx.outport_add(b, "test_result", "test results", "int", 1)
+   p_ramp_cnt = ubx.port_get(b, "ramp_cnt")
+   p_test_result = ubx.port_get(b, "test_result")
+   return true
+end
+
+local trig_cnt = 0
+local test_result = 999
+
+function step(block)
+   trig_cnt=trig_cnt+1
+
+   local n, res = p_ramp_cnt:read()
+   if trig_cnt ~= res:tolua() then
+      test_result = -1
+   end
+
+   ubx.port_write(p_test_result, test_result)
+end
+
+function cleanup(block)
+   ubx.port_rm(block, "ramp_cnt")
+   ubx.port_rm(block, "tstats")
+end
+]]
+
+local sys1 = bd.system {
+   imports = { "stdtypes", "ptrig", "ramp_uint64", "lfds_cyclic", "luablock" },
+   blocks = {
+      { name="ramp", type="ramp_uint64" },
+      { name="tester", type="lua/luablock" },
+      { name="trig", type="std_triggers/ptrig" },
+   },
+   connections = {
+      { src="ramp.out", tgt="tester.ramp_cnt" },
+   },
+
+   configurations = {
+      { name="ramp", config = { start=0, slope=1 } },
+      { name="tester", config = { lua_str=count_num_trigs } },
+      { name="trig", config = { period = {sec=0, usec=100000 },
+				trig_blocks={
+				   { b="#ramp", num_steps=1, measure=0 },
+				   { b="#tester", num_steps=1, measure=0 } } } },
+   },
+}
+
+function test_launch()
+   local ni = sys1:launch{ nostart=true, verbose=false }
+   local p_result = ubx.port_clone_conn(ni:b("tester"), "test_result")
+   sys1:startup(ni)
+   ubx.clock_mono_sleep(1)
+   ni:b("trig"):stop()
+   local _, res = p_result:read()
+   assert_equals(res:tolua(), 999)
+end
+
+os.exit( luaunit.LuaUnit.run() )

--- a/tools/ubx_launch
+++ b/tools/ubx_launch
@@ -10,6 +10,7 @@ local function usage()
    print( [=[
 microblx function block model system launcher
    usage: ubx_launch OPTIONS -c <conf file>
+      -b               listen on given block state to shutdown
       -c               .usc or .json model file to launch
       -nodename        name to give to node
       -nostart         instantiate and configure, but don't start
@@ -20,9 +21,14 @@ microblx function block model system launcher
 ]=])
 end
 
+local function isempty(s)
+  return s == nil or s == ''
+end
+
 local opttab=utils.proc_args(arg)
 local nodename
 local conf_file
+local monitorblock
 
 if #arg==1 or opttab['-h'] then
    usage(); os.exit(1)
@@ -37,6 +43,9 @@ end
 
 local suc
 suc, model = bd.load(conf_file)
+if (opttab['-b'] and opttab['-b'][1]) then
+   monitorblock = opttab['-b'][1]
+end
 
 if not suc then
    print(model)
@@ -85,6 +94,12 @@ if not opttab['-i'] then
    end
    if (duration > 0) then
       ubx.clock_mono_sleep(duration)
+   elseif not isempty(monitorblock) then
+      ubx.clock_mono_sleep(1)
+      local monblock = ni:block_get(monitorblock)
+      while (monblock:get_block_state() == 'active') do
+         ubx.clock_mono_sleep(1)
+      end
    else
       while true do
          ubx.clock_mono_sleep(60)

--- a/tools/ubx_launch
+++ b/tools/ubx_launch
@@ -2,7 +2,7 @@
 -- -*- lua -*-
 
 ubx = require("ubx")
-local bd = require("blockdiagram")
+bd = require("blockdiagram")
 local utils = require("utils")
 local ts = tostring
 

--- a/tools/ubx_launch
+++ b/tools/ubx_launch
@@ -1,7 +1,7 @@
 #!/usr/bin/env luajit
 -- -*- lua -*-
 
-local ubx = require("ubx")
+ubx = require("ubx")
 local bd = require("blockdiagram")
 local utils = require("utils")
 local ts = tostring
@@ -21,7 +21,7 @@ microblx function block model system launcher
 end
 
 local opttab=utils.proc_args(arg)
-local nodename="node-"..os.date("%Y%m%d_%H%M%S")
+local nodename
 local conf_file
 
 if #arg==1 or opttab['-h'] then
@@ -35,7 +35,8 @@ else
    conf_file = opttab['-c'][1]
 end
 
-local suc, model = bd.load(conf_file)
+local suc
+suc, model = bd.load(conf_file)
 
 if not suc then
    print(model)
@@ -89,8 +90,6 @@ if not opttab['-i'] then
          ubx.clock_mono_sleep(60)
       end
    end
+   model:pulldown(ni)
 end
 
-model:pulldown{nodename=nodename,
-	       verbose=true,
-               nostart=opttab['-nostart']}


### PR DESCRIPTION
extend ubx_launch to  support monitoring the state of a given block.
In case the block switches its state to  not `active` the launcher will terminate.