### PR TITLE
Use correct version to load libubx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ stamp-h1
 std_blocks/lfds_buffers/liblfds611/bin/
 std_blocks/lfds_buffers/liblfds611/obj/
 libubx/ubx0.pc
+lua/ubx.lua

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,9 @@
 m4_define([package_version_major],[0])
 m4_define([package_version_minor],[6])
-m4_define([package_version_micro],[2])
+m4_define([package_version_micro],[3])
 
 m4_define([libubx_if_current], [7])  dnl inc if IF added, removed or changed
-m4_define([libubx_if_revision], [2]) dnl always inc if src changed, zero if current is inc'ed
+m4_define([libubx_if_revision], [3]) dnl always inc if src changed, zero if current is inc'ed
 m4_define([libubx_if_age], [1])      dnl inc if API changes are backwards compatible, zero otherwise
 
 AC_INIT([ubx], [package_version_major.package_version_minor.package_version_micro])
@@ -29,6 +29,8 @@ AC_SUBST([UBX_VER], [package_version_major.package_version_minor])
 AC_SUBST([UBX_LT_VER], [libubx_if_current:libubx_if_revision:libubx_if_age])
 AC_SUBST([UBX_MODDIR], [$libdir/$PACKAGE/$UBX_VER])
 AC_SUBST([UBX_CFLAGS], ["-Wall -Wextra -Werror"])
+AC_SUBST([UBX_IF_CURRENT], [libubx_if_current])
+AC_SUBST([UBX_IF_AGE], [libubx_if_age])
 
 AC_ARG_ENABLE([tsc-timers],
   AS_HELP_STRING([--enable-tsc-timers], [Enable TSC timers (POSIX timers disabled)]),

--- a/lua/Makefile.am
+++ b/lua/Makefile.am
@@ -5,3 +5,8 @@ luajitmod_SCRIPTS = ubx.lua \
 		reflect.lua \
 		blockdiagram.lua \
 		umf.lua
+
+UBX_IF = $(shell expr $(UBX_IF_CURRENT) - $(UBX_IF_AGE))
+
+ubx.lua: ubx.lua.source
+	cat $(srcdir)/ubx.lua.source | sed -e "s/UBX_IF_CURRENT/$(UBX_IF)/g" > ubx.lua

--- a/lua/Makefile.am
+++ b/lua/Makefile.am
@@ -9,4 +9,4 @@ luajitmod_SCRIPTS = ubx.lua \
 UBX_IF = $(shell expr $(UBX_IF_CURRENT) - $(UBX_IF_AGE))
 
 ubx.lua: ubx.lua.source
-	cat $(srcdir)/ubx.lua.source | sed -e "s/UBX_IF_CURRENT/$(UBX_IF)/g" > ubx.lua
+	cat $(srcdir)/ubx.lua.source | sed -e "s/UBX_IF/$(UBX_IF)/g" > ubx.lua

--- a/lua/ubx.lua.source
+++ b/lua/ubx.lua.source
@@ -101,7 +101,7 @@ local load_files = {
    "include/ubx/ubx_uthash_ffi.h",
    "include/ubx/ubx_types.h",
    "include/ubx/ubx_proto.h",
-   "lib/libubx.so"
+   "lib/libubx.so.UBX_IF_CURRENT"
 }
 
 -- possible file prefixes for above headers and libraries
@@ -127,7 +127,7 @@ local function load_ubx_ffi(prefix)
    ffi.cdef(read_file(prefix.."/include/ubx/ubx_uthash_ffi.h"))
    ffi.cdef(read_file(prefix.."/include/ubx/ubx_types.h"))
    ffi.cdef(read_file(prefix.."/include/ubx/ubx_proto.h"))
-   ubx=ffi.load(prefix.."/lib/libubx.so")
+   ubx=ffi.load(prefix.."/lib/libubx.so.UBX_IF_CURRENT")
    setmetatable(M, { __index=function(t,k) return ubx["ubx_"..k] end })
    M.ubx=ubx
 end

--- a/lua/ubx.lua.source
+++ b/lua/ubx.lua.source
@@ -101,7 +101,7 @@ local load_files = {
    "include/ubx/ubx_uthash_ffi.h",
    "include/ubx/ubx_types.h",
    "include/ubx/ubx_proto.h",
-   "lib/libubx.so.UBX_IF_CURRENT"
+   "lib/libubx.so.UBX_IF"
 }
 
 -- possible file prefixes for above headers and libraries
@@ -127,7 +127,7 @@ local function load_ubx_ffi(prefix)
    ffi.cdef(read_file(prefix.."/include/ubx/ubx_uthash_ffi.h"))
    ffi.cdef(read_file(prefix.."/include/ubx/ubx_types.h"))
    ffi.cdef(read_file(prefix.."/include/ubx/ubx_proto.h"))
-   ubx=ffi.load(prefix.."/lib/libubx.so.UBX_IF_CURRENT")
+   ubx=ffi.load(prefix.."/lib/libubx.so.UBX_IF")
    setmetatable(M, { __index=function(t,k) return ubx["ubx_"..k] end })
    M.ubx=ubx
 end


### PR DESCRIPTION
NOTE: Under Linux, the version appended to the library file is
(current - age).age.revision, hence we subtract the age from
the current value