### PR TITLE
Add explicit -std=c++11 flag in cppdemo Makefile

### DIFF
--- a/std_blocks/cppdemo/Makefile.am
+++ b/std_blocks/cppdemo/Makefile.am
@@ -9,7 +9,7 @@ CLEANFILES = $(BUILT_SOURCES)
 cppdemo_la_SOURCES = cppdemo.cpp
 cppdemo_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
 cppdemo_la_LIBADD = $(top_builddir)/libubx/libubx.la
-cppdemo_la_CPPFLAGS = -I$(top_srcdir)/libubx
+cppdemo_la_CPPFLAGS = -I$(top_srcdir)/libubx -std=c++11
 
 %.h.hexarr: %.h
 	$(top_srcdir)/tools/ubx-tocarr -s $< -d $<.hexarr


### PR DESCRIPTION
Hi Markus,

On my Ubuntu 16.04 g++ 5.4.0-6ubuntu1~16.04.12, microblx failed to build (on the most recent dev branch), with an error on cppdemo, stating explicitly the need for `-std=c++11`.

This pull request does nothing else than adding that flag in the makefile.am (which fixed the problem for me).

You should check it does not introduce problems with whatever setup you usually use for building and testing microblx
