### PR TITLE
Support for dynamic PTHREAD_STACK_MIN

### DIFF
--- a/std_blocks/trig/ptrig.c
+++ b/std_blocks/trig/ptrig.c
@@ -235,9 +235,9 @@ int ptrig_handle_config(ubx_block_t *b)
 	assert(len >= 0);
 
 	if (len > 0) {
-		if (*stacksize < PTHREAD_STACK_MIN) {
-			ubx_err(b, "stacksize (%zd) less than PTHREAD_STACK_MIN (%d)",
-				*stacksize, PTHREAD_STACK_MIN);
+		if (*stacksize < (size_t)PTHREAD_STACK_MIN) {
+			ubx_err(b, "stacksize (%zd) less than PTHREAD_STACK_MIN (%ld)",
+				*stacksize, (long)PTHREAD_STACK_MIN);
 			goto out;
 		}
 


### PR DESCRIPTION
On certain systems PTHREAD_STACK_MIN is dynamic and translates to a sysconf call which has a return type of long. With all the warnings turned on and treating them as errors, the code is then unbuildable.